### PR TITLE
Removed upload-dsym.sh from Xcode project

### DIFF
--- a/TestFairySDK.xcodeproj/project.pbxproj
+++ b/TestFairySDK.xcodeproj/project.pbxproj
@@ -15,7 +15,6 @@
 		420017681D049A7300B5FB37 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 420017631D049A7300B5FB37 /* SystemConfiguration.framework */; };
 		420017951D049DA000B5FB37 /* libTestFairy.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 420017921D049DA000B5FB37 /* libTestFairy.a */; };
 		420017961D049DA000B5FB37 /* TestFairy.h in Headers */ = {isa = PBXBuildFile; fileRef = 420017931D049DA000B5FB37 /* TestFairy.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		420017971D049DA000B5FB37 /* upload-dsym.sh in Resources */ = {isa = PBXBuildFile; fileRef = 420017941D049DA000B5FB37 /* upload-dsym.sh */; };
 		4200179C1D04A04E00B5FB37 /* TestFairySDKInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 4200179A1D04A04E00B5FB37 /* TestFairySDKInternal.h */; };
 		4200179D1D04A04E00B5FB37 /* TestFairySDKInternal.m in Sources */ = {isa = PBXBuildFile; fileRef = 4200179B1D04A04E00B5FB37 /* TestFairySDKInternal.m */; };
 /* End PBXBuildFile section */
@@ -31,7 +30,6 @@
 		420017631D049A7300B5FB37 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
 		420017921D049DA000B5FB37 /* libTestFairy.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libTestFairy.a; sourceTree = "<group>"; };
 		420017931D049DA000B5FB37 /* TestFairy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TestFairy.h; sourceTree = "<group>"; };
-		420017941D049DA000B5FB37 /* upload-dsym.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = "upload-dsym.sh"; sourceTree = "<group>"; };
 		4200179A1D04A04E00B5FB37 /* TestFairySDKInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TestFairySDKInternal.h; sourceTree = "<group>"; };
 		4200179B1D04A04E00B5FB37 /* TestFairySDKInternal.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TestFairySDKInternal.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -79,7 +77,6 @@
 			children = (
 				420017921D049DA000B5FB37 /* libTestFairy.a */,
 				420017931D049DA000B5FB37 /* TestFairy.h */,
-				420017941D049DA000B5FB37 /* upload-dsym.sh */,
 				420017501D04998400B5FB37 /* TestFairySDK.h */,
 				420017521D04998400B5FB37 /* Info.plist */,
 				4200179A1D04A04E00B5FB37 /* TestFairySDKInternal.h */,
@@ -158,7 +155,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				420017971D049DA000B5FB37 /* upload-dsym.sh in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION

/var/folders/jn/615btzlj0bvccxlv_cp20t8c0000gn/T/990DF931-E68F-4A0E-946D-70258871021C/1140505764.itmsp - Error Messages:
		The session's status is FAILED and the error description is 'failed to open ssh session. (16)'
ERROR ITMS-90035: "Invalid Signature. Code object is not signed at all. The file at path [mybswhealth.app/Frameworks/TestFairySDK.framework/upload-dsym.sh] is not properly signed. Make sure you have signed your application with a distribution certificate, not an ad hoc certificate or a development certificate. Verify that the code signing settings in Xcode are correct at the target level (which override any values at the project level). Additionally, make sure the bundle you are uploading was built using a Release target in Xcode, not a Simulator target. If you are certain your code signing settings are correct, choose "Clean All" in Xcode, delete the "build" directory in the Finder, and rebuild your release target. For more information, please consult https://developer.apple.com/library/ios/documentation/Security/Conceptual/CodeSigningGuide/Introduction/Introduction.html"